### PR TITLE
added HITB GSEC - terms at http://gsec.hitb.org/cfp/

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 	  <li><a href="https://blackhat.com/">Black Hat Briefings</a></li>
 	  <li><a href="http://codeblue.jp/">Code Blue</a></li>
 	  <li><a href="http://ffconf.org">FFconf</a></li>
+          <li><a href="http://gsec.hitb.org/">HITB GSEC</a></li>
 	  <li><a href="http://infiltratecon.net/">INFILTRATE</a></li>
 	  <li><a href="https://www.sec-t.org/">SEC-T</a></li>
 	  <li><a href="https://www.syscan.org/">Syscan</a></li>


### PR DESCRIPTION
HITB GSEC pays a USD1500 honorarium per speaking slot. Terms are detailed in the CFP at http://gsec.hitb.org/cfp/
