### PR TITLE
Add RailsConf, eurucamp, ArrrrCamp, self.conference

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,18 @@
 	  <li><a href="http://webexpo.net/">WebExpo</a></li>
 	</ul>
 
+	<h3>Cons that cover your lodging</h3>
+	<ul>
+	  <li><a href="http://arrrrcamp.be/">ArrrrCamp</a></li>
+	  <li><a href="http://eurucamp.org/">eurucamp</a></li>
+	</ul>
+
 	<h3>Cons with a fixed honorarium that might cover your expenses and opportunity cost</h3>
 	<ul>
 	  <li><a href="http://www.alterconf.com/">AlterConf</a></li>
 	  <li><a href="https://defcon.org/">DEF CON</a></li>
+	  <li><a href="http://railsconf.com/">RailsConf</a></li>
+	  <li><a href="http://selfconference.org/">self.conference</a></li>
 	</ul>
 <p>Are we missing a conference? <a href="https://github.com/abiggerhammer/conferencesthatpaytheirspeakers.org/pulls">Send us a pull request!</a> </p>
 


### PR DESCRIPTION
This site is such a great idea! These are conferences I've spoken at in the past couple years. All of them have an open CFP. I added a new section since some of them just covered the hotel. 

For self.conference, I should note that it wasn't a completely fixed honorarium, there was a certain amount you could request to cover travel based on your distance (something like $250 if you were within 200 miles, $500 if you were outside that radius)--should that be put into another new section?

Separately, would it be a good idea to add to the header that conferences covering at least the cost of the speaker's ticket is assumed? I've heard of conferences where the speakers still have to buy their own ticket in order to attend, which seems a bit odd, but hopefully that's unusual and therefore this list doesn't have to end up listing every conference that does the minimum of comping the speaker ticket at least.
